### PR TITLE
Правки

### DIFF
--- a/PostService/build.gradle
+++ b/PostService/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-database-postgresql'
 
+	implementation 'org.springframework.kafka:spring-kafka:3.2.3'
 
 	implementation 'io.grpc:grpc-netty-shaded:1.65.1'
 	implementation 'io.grpc:grpc-protobuf:1.65.1'

--- a/PostService/src/main/java/kattsyn/dev/PostService/kafka/KafkaProducerConfig.java
+++ b/PostService/src/main/java/kattsyn/dev/PostService/kafka/KafkaProducerConfig.java
@@ -1,0 +1,42 @@
+package kattsyn.dev.PostService.kafka;
+
+import kattsyn.dev.models.kafka.Post;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value(value = "${spring.kafka.producer.bootstrap-servers}")
+    private String bootstrapAddress;
+
+    @Bean
+    public ProducerFactory<String, Post> postProducerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(
+                ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                bootstrapAddress);
+        configProps.put(
+                ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                StringSerializer.class);
+        configProps.put(
+                ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Post> postKafkaTemplate() {
+        return new KafkaTemplate<>(postProducerFactory());
+    }
+}

--- a/PostService/src/main/java/kattsyn/dev/PostService/kafka/KafkaSender.java
+++ b/PostService/src/main/java/kattsyn/dev/PostService/kafka/KafkaSender.java
@@ -1,0 +1,23 @@
+package kattsyn.dev.PostService.kafka;
+
+import kattsyn.dev.models.kafka.Post;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@AllArgsConstructor
+public class KafkaSender {
+
+    private final KafkaTemplate<String, Post> kafkaTemplate;
+
+    public void sendPost(Post post, String topicName) {
+        log.info("---------------------");
+        log.info("Sending Json Serializer : {}", post);
+        log.info("---------------------");
+
+        kafkaTemplate.send(topicName, post);
+    }
+}

--- a/PostService/src/main/java/kattsyn/dev/PostService/kafka/KafkaTopicConfig.java
+++ b/PostService/src/main/java/kattsyn/dev/PostService/kafka/KafkaTopicConfig.java
@@ -1,0 +1,27 @@
+package kattsyn.dev.PostService.kafka;
+
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.core.KafkaAdmin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class KafkaTopicConfig {
+    @Value(value = "${spring.kafka.producer.bootstrap-servers}")
+    private String bootstrapAddress;
+
+    @Bean
+    public KafkaAdmin kafkaAdmin() {
+        Map<String, Object> configs = new HashMap<>();
+        configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+        return new KafkaAdmin(configs);
+    }
+
+    @Bean
+    public NewTopic topic1() {
+        return new NewTopic("post", 1, (short) 1);
+    }
+}

--- a/PostService/src/main/resources/application.yml
+++ b/PostService/src/main/resources/application.yml
@@ -13,6 +13,10 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+  kafka:
+    producer:
+      bootstrap-servers: "broker:9099"
+      client-id: "post-service"
 grpc:
   server:
     port: 9090

--- a/SocialNetwork/src/main/java/kattsyn/dev/SocialNetwork/controllers/PostController.java
+++ b/SocialNetwork/src/main/java/kattsyn/dev/SocialNetwork/controllers/PostController.java
@@ -7,7 +7,7 @@ import kattsyn.dev.SocialNetwork.dtos.postservice.CreatePostRequestDTO;
 import kattsyn.dev.SocialNetwork.dtos.postservice.EditPostRequestDTO;
 import kattsyn.dev.SocialNetwork.exceptions.AppException;
 import kattsyn.dev.SocialNetwork.services.PostServiceGrpc;
-import kattsyn.dev.SocialNetwork.utils.KafkaSender;
+import kattsyn.dev.SocialNetwork.kafka.KafkaSender;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/SocialNetwork/src/main/java/kattsyn/dev/SocialNetwork/kafka/KafkaProducerConfig.java
+++ b/SocialNetwork/src/main/java/kattsyn/dev/SocialNetwork/kafka/KafkaProducerConfig.java
@@ -1,4 +1,4 @@
-package kattsyn.dev.SocialNetwork.configs;
+package kattsyn.dev.SocialNetwork.kafka;
 
 
 import org.apache.kafka.clients.producer.ProducerConfig;

--- a/SocialNetwork/src/main/java/kattsyn/dev/SocialNetwork/kafka/KafkaSender.java
+++ b/SocialNetwork/src/main/java/kattsyn/dev/SocialNetwork/kafka/KafkaSender.java
@@ -1,4 +1,4 @@
-package kattsyn.dev.SocialNetwork.utils;
+package kattsyn.dev.SocialNetwork.kafka;
 
 import kattsyn.dev.models.kafka.Event;
 import lombok.AllArgsConstructor;

--- a/SocialNetwork/src/main/java/kattsyn/dev/SocialNetwork/kafka/KafkaTopicConfig.java
+++ b/SocialNetwork/src/main/java/kattsyn/dev/SocialNetwork/kafka/KafkaTopicConfig.java
@@ -1,4 +1,4 @@
-package kattsyn.dev.SocialNetwork.configs;
+package kattsyn.dev.SocialNetwork.kafka;
 
 import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.NewTopic;

--- a/SocialNetwork/src/main/java/kattsyn/dev/SocialNetwork/services/StatService.java
+++ b/SocialNetwork/src/main/java/kattsyn/dev/SocialNetwork/services/StatService.java
@@ -2,7 +2,7 @@ package kattsyn.dev.SocialNetwork.services;
 
 import kattsyn.dev.models.kafka.Event;
 import kattsyn.dev.models.kafka.Events;
-import kattsyn.dev.SocialNetwork.utils.KafkaSender;
+import kattsyn.dev.SocialNetwork.kafka.KafkaSender;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/StatService/src/main/java/kattsyn/dev/StatService/entities/Like.java
+++ b/StatService/src/main/java/kattsyn/dev/StatService/entities/Like.java
@@ -11,16 +11,19 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "likes")
+@Table(
+        name = "likes",
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"post_id", "user_id"})}
+)
 public class Like {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    Long id;
+    private Long id;
     @Column(name = "post_id")
-    Long postId;
+    private Long postId;
     @Column(name = "user_id")
-    Long userId;
+    private Long userId;
 
     public Like(Long postId, Long userId) {
         this.postId = postId;

--- a/StatService/src/main/java/kattsyn/dev/StatService/entities/Like.java
+++ b/StatService/src/main/java/kattsyn/dev/StatService/entities/Like.java
@@ -1,0 +1,29 @@
+package kattsyn.dev.StatService.entities;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "likes")
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+    @Column(name = "post_id")
+    Long postId;
+    @Column(name = "user_id")
+    Long userId;
+
+    public Like(Long postId, Long userId) {
+        this.postId = postId;
+        this.userId = userId;
+    }
+}

--- a/StatService/src/main/java/kattsyn/dev/StatService/entities/Post.java
+++ b/StatService/src/main/java/kattsyn/dev/StatService/entities/Post.java
@@ -1,9 +1,6 @@
 package kattsyn.dev.StatService.entities;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/StatService/src/main/java/kattsyn/dev/StatService/kafka/EventTypeKafkaListener.java
+++ b/StatService/src/main/java/kattsyn/dev/StatService/kafka/EventTypeKafkaListener.java
@@ -1,4 +1,4 @@
-package kattsyn.dev.StatService.configs;
+package kattsyn.dev.StatService.kafka;
 
 import kattsyn.dev.models.kafka.Event;
 import kattsyn.dev.StatService.services.PostService;

--- a/StatService/src/main/java/kattsyn/dev/StatService/kafka/KafkaConsumerConfig.java
+++ b/StatService/src/main/java/kattsyn/dev/StatService/kafka/KafkaConsumerConfig.java
@@ -1,6 +1,7 @@
-package kattsyn.dev.StatService.configs;
+package kattsyn.dev.StatService.kafka;
 
 import kattsyn.dev.models.kafka.Event;
+import kattsyn.dev.models.kafka.Post;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -47,6 +48,31 @@ public class KafkaConsumerConfig {
         ConcurrentKafkaListenerContainerFactory<String, Event> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(eventConsumerFactory());
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, Post> postConsumerFactory() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(
+                ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                bootstrapAddress);
+        props.put(
+                ConsumerConfig.GROUP_ID_CONFIG,
+                "post");
+        return new DefaultKafkaConsumerFactory<>(
+                props,
+                new StringDeserializer(),
+                new ErrorHandlingDeserializer<>(new JsonDeserializer<>(Post.class))
+        );
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Post>
+    postKafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Post> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(postConsumerFactory());
         return factory;
     }
 }

--- a/StatService/src/main/java/kattsyn/dev/StatService/kafka/PostTypeKafkaListener.java
+++ b/StatService/src/main/java/kattsyn/dev/StatService/kafka/PostTypeKafkaListener.java
@@ -1,0 +1,29 @@
+package kattsyn.dev.StatService.kafka;
+
+
+import kattsyn.dev.models.kafka.Post;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaHandler;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+@KafkaListener(id = "postListener", topics = "post", containerFactory = "postKafkaListenerContainerFactory")
+public class PostTypeKafkaListener {
+
+
+    @KafkaHandler
+    public void listenGroupEvent(String data) {
+        log.info("Received message [{}] in groupMessage", data);
+    }
+
+
+    @KafkaHandler
+    void listenGroupEvent(Post post) {
+        log.info("Received event [{}] in groupPost", post);
+        //todo: добавить добавление поста в таблицу
+    }
+}

--- a/StatService/src/main/java/kattsyn/dev/StatService/kafka/PostTypeKafkaListener.java
+++ b/StatService/src/main/java/kattsyn/dev/StatService/kafka/PostTypeKafkaListener.java
@@ -1,6 +1,7 @@
 package kattsyn.dev.StatService.kafka;
 
 
+import kattsyn.dev.StatService.services.PostService;
 import kattsyn.dev.models.kafka.Post;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +15,8 @@ import org.springframework.stereotype.Component;
 @KafkaListener(id = "postListener", topics = "post", containerFactory = "postKafkaListenerContainerFactory")
 public class PostTypeKafkaListener {
 
+    private final PostService postService;
+
 
     @KafkaHandler
     public void listenGroupEvent(String data) {
@@ -24,6 +27,6 @@ public class PostTypeKafkaListener {
     @KafkaHandler
     void listenGroupEvent(Post post) {
         log.info("Received event [{}] in groupPost", post);
-        //todo: добавить добавление поста в таблицу
+        postService.createPost(post);
     }
 }

--- a/StatService/src/main/java/kattsyn/dev/StatService/repositories/LikeRepository.java
+++ b/StatService/src/main/java/kattsyn/dev/StatService/repositories/LikeRepository.java
@@ -1,0 +1,7 @@
+package kattsyn.dev.StatService.repositories;
+
+import kattsyn.dev.StatService.entities.Like;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikeRepository extends JpaRepository<Like, Long> {
+}

--- a/StatService/src/main/java/kattsyn/dev/StatService/repositories/LikeRepository.java
+++ b/StatService/src/main/java/kattsyn/dev/StatService/repositories/LikeRepository.java
@@ -3,5 +3,9 @@ package kattsyn.dev.StatService.repositories;
 import kattsyn.dev.StatService.entities.Like;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LikeRepository extends JpaRepository<Like, Long> {
+
+    Optional<Like> findByPostIdAndUserId(Long postId, Long userId);
 }

--- a/StatService/src/main/java/kattsyn/dev/StatService/services/LikeService.java
+++ b/StatService/src/main/java/kattsyn/dev/StatService/services/LikeService.java
@@ -5,11 +5,17 @@ import kattsyn.dev.StatService.repositories.LikeRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 public class LikeService {
 
     private final LikeRepository likeRepository;
+
+    public Optional<Like> findByPostIdAndUserId(Long postId, Long userId) {
+        return likeRepository.findByPostIdAndUserId(postId, userId);
+    }
 
     public Like save(Like like) {
         return likeRepository.save(like);

--- a/StatService/src/main/java/kattsyn/dev/StatService/services/LikeService.java
+++ b/StatService/src/main/java/kattsyn/dev/StatService/services/LikeService.java
@@ -1,0 +1,17 @@
+package kattsyn.dev.StatService.services;
+
+import kattsyn.dev.StatService.entities.Like;
+import kattsyn.dev.StatService.repositories.LikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final LikeRepository likeRepository;
+
+    public Like save(Like like) {
+        return likeRepository.save(like);
+    }
+}

--- a/StatService/src/main/resources/application.yml
+++ b/StatService/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     driver-class-name: org.postgresql.Driver
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:

--- a/StatService/src/main/resources/db/migration/V202409012154__init.sql
+++ b/StatService/src/main/resources/db/migration/V202409012154__init.sql
@@ -22,3 +22,12 @@ CREATE TABLE events
     user_id BIGINT,
     foreign key (post_id) references posts (id)
 );
+CREATE TABLE likes
+(
+    id        BIGINT PRIMARY KEY,
+    user_id   BIGINT,
+    post_id   BIGINT,
+    timestamp TIMESTAMP WITHOUT TIME ZONE,
+    FOREIGN KEY (post_id) REFERENCES posts (id),
+    UNIQUE (user_id, post_id)
+);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
     depends_on:
       - postgres_user_service
       - postservice
+      - broker
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres_user_service:5432/user_service_db
       SERVER_PORT: 8189
@@ -67,12 +68,14 @@ services:
       - "9090:9090"
     depends_on:
       - postgres_post_service
+      - broker
     environment:
       GRPC_SERVER_PORT: 9090
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres_post_service:5433/post_service_db
       SPRING_DATASOURCE_USER: kattsyn
       SPRING_DATASOURCE_PASSWORD: katt
       SPRING_JPA_HIBERNATE_DDL-AUTO: create
+      KAFKA_PRODUCER_BOOTSTRAP-SERVERS: 'broker:9099'
   
   postgres_post_service:
     image: postgres:latest

--- a/grpc/src/main/java/kattsyn/dev/models/kafka/Post.java
+++ b/grpc/src/main/java/kattsyn/dev/models/kafka/Post.java
@@ -1,0 +1,16 @@
+package kattsyn.dev.models.kafka;
+
+public class Post {
+    Long postId;
+    Long authorId;
+    String header;
+    String postContent;
+
+
+    public Post(Long postId, Long authorId, String header, String postContent) {
+        this.postId = postId;
+        this.authorId = authorId;
+        this.header = header;
+        this.postContent = postContent;
+    }
+}

--- a/grpc/src/main/java/kattsyn/dev/models/kafka/Post.java
+++ b/grpc/src/main/java/kattsyn/dev/models/kafka/Post.java
@@ -1,10 +1,10 @@
 package kattsyn.dev.models.kafka;
 
 public class Post {
-    Long postId;
-    Long authorId;
-    String header;
-    String postContent;
+    private Long postId;
+    private Long authorId;
+    private String header;
+    private String postContent;
 
 
     public Post(Long postId, Long authorId, String header, String postContent) {
@@ -12,5 +12,49 @@ public class Post {
         this.authorId = authorId;
         this.header = header;
         this.postContent = postContent;
+    }
+
+    public Post(){}
+
+    public Long getPostId() {
+        return postId;
+    }
+
+    public void setPostId(Long postId) {
+        this.postId = postId;
+    }
+
+    public Long getAuthorId() {
+        return authorId;
+    }
+
+    public void setAuthorId(Long authorId) {
+        this.authorId = authorId;
+    }
+
+    public String getHeader() {
+        return header;
+    }
+
+    public void setHeader(String header) {
+        this.header = header;
+    }
+
+    public String getPostContent() {
+        return postContent;
+    }
+
+    public void setPostContent(String postContent) {
+        this.postContent = postContent;
+    }
+
+    @Override
+    public String toString() {
+        return "Post{" +
+                "postId=" + postId +
+                ", authorId=" + authorId +
+                ", header='" + header + '\'' +
+                ", postContent='" + postContent + '\'' +
+                '}';
     }
 }


### PR DESCRIPTION
1. Немного поменял логику обработки входящего события. Разделил addEventAndCheckIfLikedAlready() на два метода.
2. Добавил таблицу учета лайков, теперь на уровне базы нельзя добавить второй лайк на тот же пост тому же пользователю. (в описании сущности указал уникальным сочетание post_id + user_id, также сделал и в миграции)
3. При создании поста PostService теперь отправляет информацию о всем посте в kafka, а StatService потом создает затем его себе. (Ранее при получении события о лайке/просмотре, если не было поста в БД, то он через gRPC шел в PostService, чтобы узнать author_id и затем создавал его у себя (на случай, если пост не дойдет как-то при создании, такая реализация на всякий случай осталась, также сходит туда если не найдет у себя пост) ).
4. Файлы связанные с kafka, будь то TopicConfig или ConsumerConfig или KafkaSender перенесены в отдельные пакеты с именем "kafka".